### PR TITLE
Fix title BlogPost title style

### DIFF
--- a/src/content/blog/230919-another-blogpost.md
+++ b/src/content/blog/230919-another-blogpost.md
@@ -1,5 +1,5 @@
 ---
-title: "Another blogpost"
+title: "Another blogpost with a long title"
 description: "Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro."
 pubDate: "2023-09-19T01:09:01.514Z"
 heroImage: "/blog-placeholder.jpg"

--- a/src/layouts/Posts.astro
+++ b/src/layouts/Posts.astro
@@ -28,7 +28,7 @@ type PostType = {
 >
   {
     posts?.slice(0, config.site.pageSize).map((post: PostType) => (
-      <article class="flex w-full flex-col items-start justify-between">
+      <article class="flex w-full flex-col items-start">
         <div class="rounded-lg block overflow-hidden mb-4">
           {post.data.heroImage && (
             <figure class="w-auto h-auto md:h-[150px] object-cover">


### PR DESCRIPTION
The `justify-between` is forcing the boxes to align, but when the title is multiline the Blogposts in the same row are creating extra space.

Current style:

![image](https://github.com/gndx/ev0-astro-theme/assets/12125288/024bd478-d340-49cc-ba13-97668d0bfd5b)

Fix reference: 

![image](https://github.com/gndx/ev0-astro-theme/assets/12125288/1a9a3b4f-ed9b-4fe6-a4a0-9b47b9141990)
